### PR TITLE
Refactor dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,18 @@
+Opensafely fork of databricks-api package
+=========================================
+
+This package is forked for the sole reason to change the default dependencies.
+
+The upstream dependencies are hardcoded and problematic for us, in that they
+depend on `pyive[hive]` explicitly, which pulls in `sasl`, which is hard to
+install and not a hard requirement, and `pyodbc`, which we do not want as we
+are using `pyhive`
+
+So this fork alters the dependencies to a) just be the more minimal `[pyhive,
+thift]`, not `pyhive[hive]` and b) make `pyodbc` and `pyhive` optional extras
+so you can choose between them.
+
+
 databricks-dbapi
 ================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,15 @@ include = ["CHANGELOG.rst"]
 
 [tool.poetry.extras]
 sqlalchemy = ["sqlalchemy"]
+pyodbc = ["pyodbc"]
+pyhive = ["pyhive", "thrift"]
 
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.5"
-pyhive = {version = "^0.6.1", extras = ["hive"]}
+pyhive = {version = "^0.6.1", optional = true}
+thrift = {version = "^0.15.0", optional = true}
 sqlalchemy = {version = "^1.3", optional = true}
-pyodbc = "^4.0.30"
+pyodbc = {version = "^4.0.30", optional = true}
 
 [tool.poetry.dev-dependencies]
 black = {version = "^20.8b1", python = "^3.7" }


### PR DESCRIPTION
1) relax pyhive requriements to not include full extras
2) make pyhive and pyodbc optional extras so you can use one or the
   other.